### PR TITLE
Fix giveitem and contextmenu

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ Project-Sloth's FiveM Inventory System Redesigned to Look Like and Feel like NoP
 
 I removed the item images for my own sanity while uploading the changes. So please use your own item images
 
+# Preview
+![image](https://github.com/i-kulgu/ps-inventory/assets/29943243/40320442-1df9-41e1-9a60-160f877492c0)
+
+
 # Credit where Credit is Due
 
 # Thanks to loljoshie for originally creating the lj-inventory we've all come to love.

--- a/client/main.lua
+++ b/client/main.lua
@@ -1011,7 +1011,7 @@ RegisterNUICallback("GiveItem", function(data, cb)
         if data.inventory == 'player' then
             local playerId = GetPlayerServerId(player)
             SetCurrentPedWeapon(PlayerPedId(),'WEAPON_UNARMED',true)
-            TriggerServerEvent("inventory:server:GiveItem", playerId, data.item.name, data.amount, data.item.slot)
+            TriggerServerEvent("inventory:server:GiveItem", playerId, data.item.name, tonumber(data.itemamt), data.item.slot)
         else
             QBCore.Functions.Notify("You do not own this item!", "error")
         end

--- a/html/js/app.js
+++ b/html/js/app.js
@@ -194,6 +194,14 @@ $(document).on("click", "#item-give", function(e) {
     }
 });
 
+// Close contextmenu on rightclick while opened
+$(document).click(function(event) {
+    var rightClickMenu = $(".ply-iteminfo-container");
+    if (!rightClickMenu.is(event.target) && rightClickMenu.has(event.target).length === 0) {
+        rightClickMenu.fadeOut(100);
+    }
+});
+
 // Autostack Quickmove
 function GetFirstFreeSlot($toInv, $fromSlot) {
     var retval = null;

--- a/html/js/app.js
+++ b/html/js/app.js
@@ -285,8 +285,8 @@ $(document).on("click", ".item-slot", function(e) {
             if (ItemData.name.split("_")[0] == "weapon") {
                 if (!$("#weapon-attachments").length) {
                     // if (ItemData.info.attachments !== null && ItemData.info.attachments !== undefined && ItemData.info.attachments.length > 0) {
-                    $(".inv-options-list").append(
-                        '<div class="inv-option-item" id="weapon-attachments"><p><i style="margin-top: 1rem" class="fas fa-gun"></i></p></div>'
+                    $(".ply-iteminfo-container").append(
+                        '<button class="inv-option-item" id="weapon-attachments"><p><i style="margin-top: 1rem" class="fas fa-gun"></i></p></button>'
                     );
                     $("#weapon-attachments").hide().fadeIn(250);
                     ClickedItemData = ItemData;

--- a/html/js/app.js
+++ b/html/js/app.js
@@ -179,12 +179,14 @@ $(document).on("click", "#item-use", function(e) {
 
 $(document).on("click", "#item-give", function(e) {
     if (contextMenuSelectedItem && ItemInventory) {
+        var itemamt = document.getElementById('item-amount-text').value
         Inventory.Close();
         $.post(
             "https://ps-inventory/GiveItem",
             JSON.stringify({
                 inventory: ItemInventory,
                 item: contextMenuSelectedItem,
+                itemamt: itemamt
             })
         );
     } else {

--- a/server/main.lua
+++ b/server/main.lua
@@ -2283,10 +2283,10 @@ RegisterServerEvent("inventory:server:GiveItem", function(target, name, amount, 
 		end
 		if RemoveItem(src, item.name, amount, item.slot) then
 			if AddItem(target, item.name, amount, false, item.info, item.created) then
-				TriggerClientEvent('inventory:client:ItemBox',target, QBCore.Shared.Items[item.name], "add")
+				TriggerClientEvent('inventory:client:ItemBox',target, QBCore.Shared.Items[item.name], "add", amount)
 				QBCore.Functions.Notify(target, "You Received "..amount..' '..item.label.." From "..Player.PlayerData.charinfo.firstname.." "..Player.PlayerData.charinfo.lastname)
 				TriggerClientEvent("inventory:client:UpdatePlayerInventory", target, true)
-				TriggerClientEvent('inventory:client:ItemBox',src, QBCore.Shared.Items[item.name], "remove")
+				TriggerClientEvent('inventory:client:ItemBox',src, QBCore.Shared.Items[item.name], "remove", amount)
 				QBCore.Functions.Notify(src, "You gave " .. OtherPlayer.PlayerData.charinfo.firstname.." "..OtherPlayer.PlayerData.charinfo.lastname.. " " .. amount .. " " .. item.label .."!")
 				TriggerClientEvent("inventory:client:UpdatePlayerInventory", src, true)
 				TriggerClientEvent('ps-inventory:client:giveAnim', src)


### PR DESCRIPTION
This PR will fix the next issues : 

- Giveitem was not working because the selected amount from the contextmenu was not send
- You couldn't close the contextmenu once you opened it, now if you left clickoutside the context menu, it will close
- Add the attachment button to the contextmenu if it is a weapon

This PR will fix the issue #9 